### PR TITLE
fix: altere o locale para pt-BR

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # SITE CONFIGURATION
 encoding: utf-8
 #baseurl: "projetokube-site"
-locale : ['en',"pt-BR"]
+locale : "pt-BR"
 # set your locale
 lang: "pt-BR"
 default_locale: "en"


### PR DESCRIPTION
Alteração no `locale` do arquivo `_config.yml`  para `pt-BR`.
Closes #80